### PR TITLE
Feat/permissions

### DIFF
--- a/app/abilities/main.ts
+++ b/app/abilities/main.ts
@@ -37,6 +37,7 @@ for (const availablePermission of availablePermissions) {
       }
 
       const superPermission = await Permission.one("manage", "all");
+
       const result = await admin
         .related("permissions")
         .query()

--- a/app/abilities/main.ts
+++ b/app/abilities/main.ts
@@ -36,11 +36,16 @@ for (const availablePermission of availablePermissions) {
         return true;
       }
 
+      const superPermission = await Permission.one("manage", "all");
       const result = await admin
         .related("permissions")
         .query()
         .where("event_id", event.id)
-        .where("permission_id", availablePermission.id)
+        .where((query) =>
+          query
+            .where("permission_id", availablePermission.id)
+            .orWhere("permission_id", superPermission ?? 0),
+        )
         .first();
 
       return Boolean(result);

--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -42,8 +42,20 @@ export default class EventController {
     return response.created(event);
   }
 
-  public async show({ params }: HttpContext) {
-    return await Event.findOrFail(params.id);
+  /**
+   * @show
+   * @operationId showEvent
+   * @description Shows one event with logged user permission
+   * @responseBody 201 - <Event>.with(permissions)
+   * @responseBody 401 - Unauthorized access
+   * @tag event
+   */
+  public async show({ params, auth }: HttpContext) {
+    return await Event.query()
+      .where("id", Number(params.id))
+      .preload("permissions", (q) =>
+        q.where("admin_permissions.admin_id", auth.user?.id ?? 0),
+      );
   }
 
   /**

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -4,16 +4,11 @@ import string from "@adonisjs/core/helpers/string";
 import {
   BaseModel,
   afterCreate,
-  belongsTo,
   column,
   hasMany,
   manyToMany,
 } from "@adonisjs/lucid/orm";
-import type {
-  BelongsTo,
-  HasMany,
-  ManyToMany,
-} from "@adonisjs/lucid/types/relations";
+import type { HasMany, ManyToMany } from "@adonisjs/lucid/types/relations";
 
 import Admin from "./admin.js";
 import Participant from "./participant.js";

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -7,11 +7,17 @@ import {
   belongsTo,
   column,
   hasMany,
+  manyToMany,
 } from "@adonisjs/lucid/orm";
-import type { BelongsTo, HasMany } from "@adonisjs/lucid/types/relations";
+import type {
+  BelongsTo,
+  HasMany,
+  ManyToMany,
+} from "@adonisjs/lucid/types/relations";
 
 import Admin from "./admin.js";
 import Participant from "./participant.js";
+import Permission from "./permission.js";
 
 // import Form from './Form.ts';
 
@@ -61,8 +67,19 @@ export default class Event extends BaseModel {
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime;
 
-  @belongsTo(() => Admin)
-  declare admin: BelongsTo<typeof Admin>;
+  @manyToMany(() => Admin, {
+    pivotTable: "admin_permissions",
+    pivotColumns: ["permission_id"],
+    pivotTimestamps: true,
+  })
+  declare admins: ManyToMany<typeof Admin>;
+
+  @manyToMany(() => Permission, {
+    pivotTable: "admin_permissions",
+    pivotColumns: ["admin_id"],
+    pivotTimestamps: true,
+  })
+  declare permissions: ManyToMany<typeof Permission>;
 
   // @belongsTo(() => Form)
   // public firstForm: BelongsTo<typeof Form>;

--- a/app/models/permission.ts
+++ b/app/models/permission.ts
@@ -13,6 +13,14 @@ export default class Permission extends BaseModel {
   @column()
   declare subject: string;
 
+  static async one(action: string, subject: string): Promise<number | null> {
+    const permission = await Permission.query()
+      .where("action", action)
+      .where("subject", subject)
+      .first();
+    return permission?.id ?? null;
+  }
+
   @manyToMany(() => Admin, {
     pivotTable: "admin_permissions",
     pivotColumns: ["event_id"],

--- a/database/seeders/permission_seeder.ts
+++ b/database/seeders/permission_seeder.ts
@@ -8,11 +8,10 @@ export default class extends BaseSeeder {
       ["action", "subject"],
       [
         { action: "manage", subject: "all" },
-        { action: "update", subject: "event" },
-        { action: "delete", subject: "event" },
-        { action: "read", subject: "form" },
-        { action: "update", subject: "form" },
-        { action: "delete", subject: "form" },
+        { action: "manage", subject: "setting" },
+        { action: "manage", subject: "form" },
+        { action: "manage", subject: "participant" },
+        { action: "manage", subject: "email" },
       ],
     );
   }

--- a/database/seeders/permission_seeder.ts
+++ b/database/seeders/permission_seeder.ts
@@ -8,6 +8,7 @@ export default class extends BaseSeeder {
       ["action", "subject"],
       [
         { action: "manage", subject: "all" },
+        { action: "manage", subject: "event" },
         { action: "manage", subject: "setting" },
         { action: "manage", subject: "form" },
         { action: "manage", subject: "participant" },


### PR DESCRIPTION
Zostały poprawnie zaimplementowane dynamiczne uprawnienia bouncer w adonisie: https://docs.adonisjs.com/guides/security/authorization

Najważniejsze elementy:

database->seeders->permission_seeder -> znajdują się tam dostępne w aplikacji uprawnienia w stylu action subject. Na razie są zaimplementowane uprawnienia manage dla podmiotów: all, event, setting, form, participant, email. W przyszłości będzie można dodać szczegółowe uprawnienia.

app->abilities->main - tu dzieje się magia sprawdzania tych dynamicznych uprawnień. Zachęcam do sprawdzenia. Root adminem, który dostaje wszystko jest: superadmin, twórca wydarzenia, admin z manage_all

następnie w dowolnym kontrolerze z requestu bierzemy obiekt bouncer i sprawdzamy dane uprawnienie:    np. `await bouncer.authorize("manage_event", event);` musimy w tym celu mieć wcześniej event. 

Całą resztę ogarnia adonis. 
