### PR TITLE
fix: fix validator display in autoswagger docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "node ace build",
-    "dev": "node ace serve --hmr",
+    "dev": "node ace serve --watch",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",


### PR DESCRIPTION
Z jakiegoś powodu, jeśli używamy `node ace serve --hmr` to autoswagger wyrzuca błąd mówiący, żeby używać `node ace serve --watch`. Gdy używamy `--hmr`, to jeśli jako `@requestBody` jest ustawiony jakiś validator, to nie będzie on wyświetlany: 
![image](https://github.com/user-attachments/assets/8e16a3e2-d02a-4a23-99cf-da0fe2d11989)

Jest już o tym issue na githubie autoswaggera: https://github.com/ad-on-is/adonis-autoswagger/issues/151