### PR TITLE
Feat/registration form

### DIFF
--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -52,7 +52,7 @@ export default class FormsController {
       });
     }
 
-    const form = await Form.create({ ...newFormData, eventId });
+    const form = await event.related("forms").create(newFormData);
 
     if (isFirstForm) {
       event.firstFormId = form.id;
@@ -126,7 +126,7 @@ export default class FormsController {
     if (
       event.firstFormId !== null &&
       event.firstFormId !== formId &&
-      isFirstForm
+      isFirstForm === true
     ) {
       return response.badRequest({
         message: "Event already has a registration form",
@@ -156,7 +156,7 @@ export default class FormsController {
       );
     }
 
-    if (isFirstForm) {
+    if (isFirstForm === true) {
       event.firstFormId = form.id;
       await event.save();
     }

--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -39,9 +39,9 @@ export default class FormsController {
   public async store({ params, request, response, bouncer }: HttpContext) {
     const eventId = Number(params.eventId);
 
-    await bouncer.authorize("manage_form", await Event.findOrFail(eventId));
-
     const event = await Event.findOrFail(eventId);
+
+    await bouncer.authorize("manage_form", event);
 
     const { attributes, isFirstForm, ...newFormData } =
       await request.validateUsing(createFormValidator);
@@ -112,8 +112,9 @@ export default class FormsController {
   public async update({ params, request, bouncer, response }: HttpContext) {
     const eventId = Number(params.eventId);
     const formId = Number(params.id);
-    await bouncer.authorize("manage_form", await Event.findOrFail(eventId));
     const event = await Event.findOrFail(eventId);
+
+    await bouncer.authorize("manage_form", event);
     const form = await Form.query()
       .where("event_id", eventId)
       .where("id", formId)

--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -55,8 +55,7 @@ export default class FormsController {
     const form = await event.related("forms").create(newFormData);
 
     if (isFirstForm) {
-      event.firstFormId = form.id;
-      await event.save();
+      await form.related("firstForm").save(event);
     }
 
     await form.related("attributes").attach(
@@ -157,12 +156,10 @@ export default class FormsController {
     }
 
     if (isFirstForm === true) {
-      event.firstFormId = form.id;
-      await event.save();
+      await form.related("firstForm").save(event);
     }
     if (isFirstForm === false && event.firstFormId === formId) {
-      event.firstFormId = null;
-      await event.save();
+      await event.merge({ firstFormId: null }).save();
     }
 
     const updatedForm = await Form.query()

--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -160,6 +160,10 @@ export default class FormsController {
       event.firstFormId = form.id;
       await event.save();
     }
+    if (isFirstForm === false && event.firstFormId === formId) {
+      event.firstFormId = null;
+      await event.save();
+    }
 
     const updatedForm = await Form.query()
       .where("event_id", eventId)

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -4,6 +4,7 @@ import { BaseModel, column, hasMany, manyToMany } from "@adonisjs/lucid/orm";
 import type { HasMany, ManyToMany } from "@adonisjs/lucid/types/relations";
 
 import Email from "#models/email";
+import Form from "#models/form";
 
 import Admin from "./admin.js";
 import Participant from "./participant.js";
@@ -82,6 +83,9 @@ export default class Event extends BaseModel {
 
   @hasMany(() => Email)
   declare emails: HasMany<typeof Email>;
+
+  @hasMany(() => Form)
+  declare forms: HasMany<typeof Form>;
 
   @column()
   declare socialMediaLinks: string[] | null;

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -10,8 +10,6 @@ import Admin from "./admin.js";
 import Participant from "./participant.js";
 import Permission from "./permission.js";
 
-// import Form from './Form.ts';
-
 export default class Event extends BaseModel {
   @column({ isPrimary: true })
   declare id: number;
@@ -74,9 +72,6 @@ export default class Event extends BaseModel {
     pivotTimestamps: true,
   })
   declare permissions: ManyToMany<typeof Permission>;
-
-  // @belongsTo(() => Form)
-  // public firstForm: BelongsTo<typeof Form>;
 
   @hasMany(() => Participant)
   declare participants: HasMany<typeof Participant>;

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -33,9 +33,6 @@ export default class Event extends BaseModel {
   declare endDate: DateTime;
 
   @column()
-  declare firstFormId: number | null;
-
-  @column()
   declare lat: number | null;
 
   @column()
@@ -81,6 +78,11 @@ export default class Event extends BaseModel {
 
   @hasMany(() => Form)
   declare forms: HasMany<typeof Form>;
+
+  @hasMany(() => Form, {
+    onQuery: (query) => query.where("is_first_form", true),
+  })
+  declare firstForm: HasMany<typeof Form>;
 
   @column()
   declare socialMediaLinks: string[] | null;

--- a/app/models/form.ts
+++ b/app/models/form.ts
@@ -6,9 +6,14 @@ import {
   beforeCreate,
   belongsTo,
   column,
+  hasOne,
   manyToMany,
 } from "@adonisjs/lucid/orm";
-import type { BelongsTo, ManyToMany } from "@adonisjs/lucid/types/relations";
+import type {
+  BelongsTo,
+  HasOne,
+  ManyToMany,
+} from "@adonisjs/lucid/types/relations";
 
 import Event from "#models/event";
 
@@ -47,6 +52,11 @@ export default class Form extends BaseModel {
 
   @belongsTo(() => Event)
   declare event: BelongsTo<typeof Event>;
+
+  @hasOne(() => Event, {
+    foreignKey: "firstFormId",
+  })
+  declare firstForm: HasOne<typeof Event>;
 
   @manyToMany(() => Attribute, {
     pivotTable: "form_definitions",

--- a/app/models/form.ts
+++ b/app/models/form.ts
@@ -6,14 +6,9 @@ import {
   beforeCreate,
   belongsTo,
   column,
-  hasOne,
   manyToMany,
 } from "@adonisjs/lucid/orm";
-import type {
-  BelongsTo,
-  HasOne,
-  ManyToMany,
-} from "@adonisjs/lucid/types/relations";
+import type { BelongsTo, ManyToMany } from "@adonisjs/lucid/types/relations";
 
 import Event from "#models/event";
 
@@ -36,6 +31,9 @@ export default class Form extends BaseModel {
   declare name: string;
 
   @column()
+  declare isFirstForm: boolean;
+
+  @column()
   declare slug: string;
 
   @column.dateTime()
@@ -52,11 +50,6 @@ export default class Form extends BaseModel {
 
   @belongsTo(() => Event)
   declare event: BelongsTo<typeof Event>;
-
-  @hasOne(() => Event, {
-    foreignKey: "firstFormId",
-  })
-  declare firstForm: HasOne<typeof Event>;
 
   @manyToMany(() => Attribute, {
     pivotTable: "form_definitions",

--- a/app/validators/form.ts
+++ b/app/validators/form.ts
@@ -14,6 +14,7 @@ export const createFormValidator = vine.compile(
     name: vine.string(),
     description: vine.string(),
     startDate: vine.date().transform(dateTimeTransform),
+    isFirstForm: vine.boolean(),
     attributes: vine
       .array(
         vine.object({
@@ -25,7 +26,6 @@ export const createFormValidator = vine.compile(
       .minLength(1),
     endDate: vine.date().transform(dateTimeTransform).optional(),
     isOpen: vine.boolean().optional(),
-    isFirstForm: vine.boolean(),
   }),
 );
 
@@ -46,7 +46,7 @@ export const updateFormValidator = vine.compile(
       .minLength(1)
       .optional(),
     isOpen: vine.boolean().optional(),
-    isFirstForm: vine.boolean(),
+    isFirstForm: vine.boolean().optional(),
   }),
 );
 

--- a/app/validators/form.ts
+++ b/app/validators/form.ts
@@ -25,6 +25,7 @@ export const createFormValidator = vine.compile(
       .minLength(1),
     endDate: vine.date().transform(dateTimeTransform).optional(),
     isOpen: vine.boolean().optional(),
+    isFirstForm: vine.boolean(),
   }),
 );
 
@@ -45,6 +46,7 @@ export const updateFormValidator = vine.compile(
       .minLength(1)
       .optional(),
     isOpen: vine.boolean().optional(),
+    isFirstForm: vine.boolean(),
   }),
 );
 

--- a/database/migrations/1733568663910_create_forms_table.ts
+++ b/database/migrations/1733568663910_create_forms_table.ts
@@ -11,7 +11,7 @@ export default class extends BaseSchema {
       table.string("slug").notNullable().unique();
       table.timestamp("start_date").defaultTo("NOW()");
       table.boolean("is_open").defaultTo(false);
-
+      table.boolean("is_first_form").defaultTo(false);
       table.text("description", "long").nullable();
       table.timestamp("end_date").nullable();
 

--- a/database/migrations/1733572231841_create_events_table.ts
+++ b/database/migrations/1733572231841_create_events_table.ts
@@ -16,11 +16,6 @@ export default class EventsSchema extends BaseSchema {
       table.string("slug", 255).notNullable();
       table.timestamp("start_date").notNullable();
       table.timestamp("end_date").notNullable();
-      table
-        .integer("first_form_id")
-        .unsigned()
-        .references("forms.id")
-        .onDelete("CASCADE");
       table.float("lat").nullable();
       table.float("long").nullable();
       table.string("primary_color", 12);


### PR DESCRIPTION
Tldr tego co zmienione:
- Do walidatora formularz dodałem boolean (isFirstForm) - uznałem, że jeżeli na froncie ta opcja działa jako switch (zawsze przyjmie jakąś wartość) to mogę uznać, że w walidacji zarówno store/update to nie musi być to pole optional
- Endpoint store: 
    - form chce być rejestracyjnym + event ma już podane id rejestracyjnego -> zwróć błąd i nie twórz formularza, 
    - Teraz tworzymy formularz 
    - Form chce być rejestracyjnym (założyłem, że jeżeli nie wywalił się na pierwszym if to w evencie firstFormId musi mieć wartość null i nie muszę tego sprawdzać) -> ustaw w evencie firstFormId na id utworzonego forma)
-  Endpoint update:
    - Jeżeli chce być rejestracyjnym + event ma podane id oraz nie jest to id takie samo jak naszego formularza -> wywal błąd bez aktualizacji formularza
    - Zaktualizuj formularz
    - Jeżeli chce być rejestracyjnym -> przypisz do eventu id formularza (ten sam case jak wcześniej się nie wysypał to mogę przypuszczać, że jest null)
    - Jeżeli formularz nie chce być rejestracyjnym a jego wartość jest przypisana w evencie to zmieniamy id w evencie na null

Inne zmiany: wyszukuję event.findorfail a do bouncera wrzuciłem jego zmienną, aby nie robić dwa razy tego samego query

Uwagi: zostałem przy nazwie firstFormId, bo nie chciałem wprowadzać niepotrzebnych zmian w bazie, ale wydaje mi się, że registrationFormId byłoby bardziej zrozumiałe, sprawdźcie proszę czy “logika” utworzonych warunków napewno objęła wszystkie case’y, szczególnie przy updacie, czy napewno nic nie pominąłem.