### PR TITLE
feat: add an endpoint to get event photo

### DIFF
--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -2,6 +2,7 @@ import { unlinkSync } from "node:fs";
 
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
+import app from "@adonisjs/core/services/app";
 import db from "@adonisjs/lucid/services/db";
 
 import Event from "#models/event";
@@ -159,5 +160,29 @@ export default class EventController {
     await db.from("admin_permissions").where("event_id", event.id).delete();
     await event.delete();
     return { message: "Event successfully deleted" };
+  }
+
+  /**
+   * @downloadPhoto
+   * @operationId downloadPhoto
+   * @description Returns event photo
+   * @tag event
+   * @responseBody 200 - photo
+   * @responseBody 400 - { message: "Event doesn't have a photo" }
+   */
+  public async downloadPhoto({ params, response }: HttpContext) {
+    const eventId = +params.eventId;
+
+    const event = await Event.findOrFail(eventId);
+
+    if (event.photoUrl === null) {
+      return response.badRequest({
+        message: `Event ${eventId} doesn't have a photo`,
+      });
+    }
+
+    const photoPath = app.makePath(event.photoUrl);
+
+    return response.download(photoPath);
   }
 }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -75,6 +75,12 @@ router
 
     router
       .group(() => {
+        router.get("photo", [EventController, "downloadPhoto"]);
+      })
+      .prefix("events/:eventId");
+
+    router
+      .group(() => {
         router.post("login", [AuthController, "login"]);
         router.post("register", [AuthController, "register"]);
         router.get("me", [AuthController, "me"]).use(middleware.auth());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `downloadPhoto` endpoint in `EventController` to download event photos, with routing in `routes.ts`.
> 
>   - **New Endpoint**:
>     - Adds `downloadPhoto` method in `EventController` to download event photos.
>     - Returns 400 error if event has no photo.
>   - **Routing**:
>     - Adds route for `downloadPhoto` in `routes.ts` under `events/:eventId/photo`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 425c3e8c7471f92e68d9c217a5add93871fa3ed3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->