### PR TITLE
feat: display first form in event

### DIFF
--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -86,7 +86,7 @@ export default class EventController {
       .preload("permissions", (q) =>
         q.where("admin_permissions.admin_id", auth.user?.id ?? 0),
       )
-      .preload("forms", (q) => q.where("is_first_form", true))
+      .preload("firstForm")
       .first();
 
     await bouncer.authorize("manage_event", event);
@@ -102,7 +102,7 @@ export default class EventController {
    */
   public async publicShow({ params }: HttpContext) {
     const event = await Event.findByOrFail("slug", params.eventSlug);
-    await event.load("forms", (q) => q.where("is_first_form", true));
+    await event.load("firstForm");
     return event;
   }
 

--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -131,7 +131,7 @@ export default class FormsController {
       await request.validateUsing(updateFormValidator);
 
     if (
-      event.firstForm.length !== 0 &&
+      event.firstForm !== null &&
       form.isFirstForm === false &&
       updates.isFirstForm === true
     ) {

--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -55,7 +55,7 @@ export default class FormsController {
     const { attributes, ...newFormData } =
       await request.validateUsing(createFormValidator);
 
-    if (newFormData.isFirstForm === true && event.firstForm.length !== 0) {
+    if (newFormData.isFirstForm === true && event.firstForm !== null) {
       return response.badRequest({
         message: "Event already has a registration form",
       });

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -90,7 +90,8 @@ export default class Event extends BaseModel {
   declare forms: HasMany<typeof Form>;
 
   @hasOne(() => Form, {
-    onQuery: (query) => query.where("is_first_form", true),
+    onQuery: (query) =>
+      query.where("is_first_form", true).preload("attributes"),
   })
   declare firstForm: HasOne<typeof Form>;
 

--- a/app/models/event.ts
+++ b/app/models/event.ts
@@ -1,7 +1,17 @@
 import { DateTime } from "luxon";
 
-import { BaseModel, column, hasMany, manyToMany } from "@adonisjs/lucid/orm";
-import type { HasMany, ManyToMany } from "@adonisjs/lucid/types/relations";
+import {
+  BaseModel,
+  column,
+  hasMany,
+  hasOne,
+  manyToMany,
+} from "@adonisjs/lucid/orm";
+import type {
+  HasMany,
+  HasOne,
+  ManyToMany,
+} from "@adonisjs/lucid/types/relations";
 
 import Email from "#models/email";
 import Form from "#models/form";
@@ -79,10 +89,10 @@ export default class Event extends BaseModel {
   @hasMany(() => Form)
   declare forms: HasMany<typeof Form>;
 
-  @hasMany(() => Form, {
+  @hasOne(() => Form, {
     onQuery: (query) => query.where("is_first_form", true),
   })
-  declare firstForm: HasMany<typeof Form>;
+  declare firstForm: HasOne<typeof Form>;
 
   @column()
   declare socialMediaLinks: string[] | null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `firstForm` handling in events from `hasMany` to `hasOne` and update related queries.
> 
>   - **Behavior**:
>     - Change `hasMany` to `hasOne` for `firstForm` in `event.ts`.
>     - Update `show()` and `publicShow()` in `events_controller.ts` to use `firstForm` instead of filtering `forms`.
>     - Update `store()` and `update()` in `forms_controller.ts` to check `firstForm` as non-null instead of length check.
>   - **Models**:
>     - Modify `Event` model to use `hasOne` for `firstForm`.
>   - **Misc**:
>     - Remove `is_first_form` filtering from `events_controller.ts` and `forms_controller.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for f669f9cace5e225966bbe77098ee2250d521c2c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->