### PR TITLE
fix: cascade delete participant_attributes on participant delete

### DIFF
--- a/database/migrations/1741025109483_alter_participant_attribute_cascade_deletes_table.ts
+++ b/database/migrations/1741025109483_alter_participant_attribute_cascade_deletes_table.ts
@@ -1,0 +1,37 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "participant_attributes";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropForeign("participant_id");
+      table
+        .foreign("participant_id")
+        .references("participants.id")
+        .onDelete("CASCADE");
+
+      table.dropForeign("attribute_id");
+      table
+        .foreign("attribute_id")
+        .references("attributes.id")
+        .onDelete("CASCADE");
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropForeign("participant_id");
+      table
+        .foreign("participant_id")
+        .references("participants.id")
+        .onDelete("NO ACTION");
+
+      table.dropForeign("attribute_id");
+      table
+        .foreign("attribute_id")
+        .references("attributes.id")
+        .onDelete("NO ACTION");
+    });
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds migration to set `onDelete: CASCADE` for `participant_id` and `attribute_id` in `participant_attributes` table.
> 
>   - **Migration**:
>     - Adds `1741025109483_alter_participant_attribute_cascade_deletes_table.ts` to modify `participant_attributes` table.
>     - Sets `onDelete: CASCADE` for `participant_id` and `attribute_id` foreign keys in `up()`.
>     - Reverts to `onDelete: NO ACTION` in `down()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 8f6d8a24b3d726505c6e67e07faee6a0f19bade1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->