### PR TITLE
Feat/slugs unique constratints

### DIFF
--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -1,13 +1,19 @@
 import vine from "@vinejs/vine";
 
+import string from "@adonisjs/core/helpers/string";
+
 export const createAttributeSchema = vine.object({
   name: vine.string(),
   slug: vine
     .string()
     .unique(
       async (db, value) =>
-        (await db.from("attributes").where("slug", value).first()) === null,
+        (await db
+          .from("attributes")
+          .where("slug", string.slug(value, { lower: true }))
+          .first()) === null,
     )
+    .transform((value) => string.slug(value, { lower: true }))
     .nullable()
     .optional(),
   type: vine.enum([
@@ -42,8 +48,12 @@ export const UpdateAttributeSchema = vine.object({
     .string()
     .unique(
       async (db, value) =>
-        (await db.from("attributes").where("slug", value).first()) === null,
+        (await db
+          .from("attributes")
+          .where("slug", string.slug(value, { lower: true }))
+          .first()) === null,
     )
+    .transform((value) => string.slug(value, { lower: true }))
     .nullable()
     .optional(),
   type: vine

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -2,7 +2,14 @@ import vine from "@vinejs/vine";
 
 export const createAttributeSchema = vine.object({
   name: vine.string(),
-  slug: vine.string().nullable().optional(),
+  slug: vine
+    .string()
+    .unique(
+      async (db, value) =>
+        (await db.from("attributes").where("slug", value).first()) === null,
+    )
+    .nullable()
+    .optional(),
   type: vine.enum([
     "text",
     "textarea",
@@ -31,7 +38,14 @@ export const createAttributeValidator = vine.compile(createAttributeSchema);
 
 export const UpdateAttributeSchema = vine.object({
   name: vine.string().optional(),
-  slug: vine.string().nullable().optional(),
+  slug: vine
+    .string()
+    .unique(
+      async (db, value) =>
+        (await db.from("attributes").where("slug", value).first()) === null,
+    )
+    .nullable()
+    .optional(),
   type: vine
     .enum([
       "text",

--- a/app/validators/event.ts
+++ b/app/validators/event.ts
@@ -18,6 +18,10 @@ export const createEventValidator = vine.compile(
     organizer: vine.string().nullable().optional(),
     slug: vine
       .string()
+      .unique(
+        async (db, value) =>
+          (await db.from("events").where("slug", value).first()) === null,
+      )
       .transform((value) => string.slug(value, { lower: true })),
     // 2025-01-05 12:00:00
     startDate: vine.date().transform(dateTimeTransform),
@@ -52,6 +56,10 @@ export const updateEventValidator = vine.compile(
     description: vine.string().nullable().optional(),
     slug: vine
       .string()
+      .unique(
+        async (db, value) =>
+          (await db.from("events").where("slug", value).first()) === null,
+      )
       .transform((value) => string.slug(value, { lower: true }))
       .optional(),
     startDate: vine.date().transform(dateTimeTransform).optional(),

--- a/app/validators/event.ts
+++ b/app/validators/event.ts
@@ -20,7 +20,10 @@ export const createEventValidator = vine.compile(
       .string()
       .unique(
         async (db, value) =>
-          (await db.from("events").where("slug", value).first()) === null,
+          (await db
+            .from("events")
+            .where("slug", string.slug(value, { lower: true }))
+            .first()) === null,
       )
       .transform((value) => string.slug(value, { lower: true })),
     // 2025-01-05 12:00:00
@@ -58,7 +61,10 @@ export const updateEventValidator = vine.compile(
       .string()
       .unique(
         async (db, value) =>
-          (await db.from("events").where("slug", value).first()) === null,
+          (await db
+            .from("events")
+            .where("slug", string.slug(value, { lower: true }))
+            .first()) === null,
       )
       .transform((value) => string.slug(value, { lower: true }))
       .optional(),

--- a/database/migrations/1741354093610_alter_make_event_slug_uniques_table.ts
+++ b/database/migrations/1741354093610_alter_make_event_slug_uniques_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "events";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.unique(["slug"]);
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropUnique(["slug"]);
+    });
+  }
+}

--- a/database/migrations/1741355166043_alter_make_attribute_slug_uniques_table.ts
+++ b/database/migrations/1741355166043_alter_make_attribute_slug_uniques_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "attributes";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.unique(["slug"]);
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropUnique(["slug"]);
+    });
+  }
+}


### PR DESCRIPTION
Closes #157
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add unique constraints to `slug` fields in `attributes` and `events` tables and update validators to enforce uniqueness.
> 
>   - **Validators**:
>     - In `attribute.ts`, `slug` field in `createAttributeSchema` and `UpdateAttributeSchema` now uses `.unique()` to ensure uniqueness in `attributes` table.
>     - In `event.ts`, `slug` field in `createEventValidator` and `updateEventValidator` now uses `.unique()` to ensure uniqueness in `events` table.
>   - **Migrations**:
>     - Adds `1741354093610_alter_make_event_slug_uniques_table.ts` to add unique constraint on `slug` in `events` table.
>     - Adds `1741355166043_alter_make_attribute_slug_uniques_table.ts` to add unique constraint on `slug` in `attributes` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for c66420ac071b6c9bfc8d54140bc818ad3f595f78. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->