### PR TITLE
fix(ci): use lockfile for building & ignore local node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# deps and build artifacts
+node_modules
+build
+tmp
+
+# file storage
+public
+
+# Build tools specific
+npm-debug.log
+yarn-error.log
+
+# Editors specific
+.fleet
+.idea
+.vscode
+
+# Platform specific
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM node:22 AS base
 # All deps stage
 FROM base AS deps
 WORKDIR /app
-ADD package.json ./
-RUN npm i
+ADD package.json package-lock.json ./
+RUN npm ci
 
 # Production only deps stage
 FROM base AS production-deps
 WORKDIR /app
-ADD package.json ./
-RUN npm i --omit=dev
+ADD package.json package-lock.json ./
+RUN npm ci --omit=dev
 
 # Build stage
 FROM base AS build


### PR DESCRIPTION
the current dockerfile was using the `npm i` command instead of `npm ci`, which allowed it to automatically & silently update dependencies.
this allowed for issues, where it could update a dependency to one that would break the build (but only if it was a minor/patch update, i.e. the dependency devs made a mistake)
coincidentally, `adonis-autoswagger` devs appear to have just made that exact mistake, adding a new required field on a public type in a minor update.
this commit fixes this issue by using `npm ci` instead.

addtionally, there was no `.dockerignore` file, which combined with the `ADD . .` command just before the build in the `Dockerfile` caused the build to actually use the dependencies installed in the local repo, outside of the container image build environment, by copying the local `node_modules` directory into the build env.
this made the bug explained earlier not reproducible locally, if your local repo had dependencies already installed.
reproducing the bug required the cleanup of the repo by running `git reset --hard` and `git clean -fdx`.
this commit fixes this issue by adding a `.dockerignore` which mostly mirrors the directories specified `.gitignore`, including the `node_modules` directory.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `npm ci` for consistent dependency management and add `.dockerignore` to prevent local `node_modules` interference in Docker builds.
> 
>   - **Dependency Management**:
>     - Change `npm i` to `npm ci` in `Dockerfile` to prevent automatic dependency updates.
>     - Ensures consistent builds by using `package-lock.json`.
>   - **Docker Build Isolation**:
>     - Add `.dockerignore` to prevent local `node_modules` from being copied into Docker build context.
>     - `.dockerignore` mirrors `.gitignore` to exclude unnecessary files and directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 3b4e24c9d13cfe2205c31c3a781c424e30cdbbdc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->