### PR TITLE
feat: add migration with show in list to true

### DIFF
--- a/database/migrations/1741355167147_alter_default_show_in_table_attribute_true.ts
+++ b/database/migrations/1741355167147_alter_default_show_in_table_attribute_true.ts
@@ -4,10 +4,14 @@ export default class extends BaseSchema {
   protected tableName = "attributes";
 
   async up() {
-    this.schema.raw(`ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT TRUE;`);
+    this.schema.raw(
+      `ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT TRUE;`,
+    );
   }
 
   async down() {
-    this.schema.raw(`ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT FALSE;`);
+    this.schema.raw(
+      `ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT FALSE;`,
+    );
   }
 }

--- a/database/migrations/1741355167147_alter_default_show_in_table_attribute_true.ts
+++ b/database/migrations/1741355167147_alter_default_show_in_table_attribute_true.ts
@@ -1,0 +1,13 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "attributes";
+
+  async up() {
+    this.schema.raw(`ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT TRUE;`);
+  }
+
+  async down() {
+    this.schema.raw(`ALTER TABLE attributes ALTER COLUMN show_in_list SET DEFAULT FALSE;`);
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds migration to set default `show_in_list` to `TRUE` in `attributes` table.
> 
>   - **Migration**:
>     - Adds migration `1741355167147_alter_default_show_in_table_attribute_true.ts` to set default `show_in_list` to `TRUE` in `attributes` table.
>     - `up()` method alters column default to `TRUE`.
>     - `down()` method reverts column default to `FALSE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for a21b83180170d859be4b578164fcbe6ed41f05d8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->