### PR TITLE
feat!: use iso date format in requests

### DIFF
--- a/app/validators/event.ts
+++ b/app/validators/event.ts
@@ -26,9 +26,9 @@ export const createEventValidator = vine.compile(
             .first()) === null,
       )
       .transform((value) => string.slug(value, { lower: true })),
-    // 2025-01-05 12:00:00
-    startDate: vine.date().transform(dateTimeTransform),
-    endDate: vine.date().transform(dateTimeTransform),
+    // 2025-01-05T12:00:00
+    startDate: vine.date({ formats: ["iso8601"] }).transform(dateTimeTransform),
+    endDate: vine.date({ formats: ["iso8601"] }).transform(dateTimeTransform),
     lat: vine.number().nullable().optional(),
     location: vine.string().nullable().optional(),
     long: vine.number().nullable().optional(),
@@ -69,8 +69,14 @@ export const updateEventValidator = vine.compile(
       )
       .transform((value) => string.slug(value, { lower: true }))
       .optional(),
-    startDate: vine.date().transform(dateTimeTransform).optional(),
-    endDate: vine.date().transform(dateTimeTransform).optional(),
+    startDate: vine
+      .date({ formats: ["iso8601"] })
+      .transform(dateTimeTransform)
+      .optional(),
+    endDate: vine
+      .date({ formats: ["iso8601"] })
+      .transform(dateTimeTransform)
+      .optional(),
     location: vine.string().nullable().optional(),
     lat: vine.number().nullable().optional(),
     long: vine.number().nullable().optional(),

--- a/app/validators/form.ts
+++ b/app/validators/form.ts
@@ -13,7 +13,7 @@ export const createFormValidator = vine.compile(
   vine.object({
     name: vine.string(),
     description: vine.string(),
-    startDate: vine.date().transform(dateTimeTransform),
+    startDate: vine.date({ formats: ["iso8601"] }).transform(dateTimeTransform),
     isFirstForm: vine.boolean(),
     attributes: vine
       .array(
@@ -24,7 +24,10 @@ export const createFormValidator = vine.compile(
         }),
       )
       .minLength(1),
-    endDate: vine.date().transform(dateTimeTransform).optional(),
+    endDate: vine
+      .date({ formats: ["iso8601"] })
+      .transform(dateTimeTransform)
+      .optional(),
     isOpen: vine.boolean().optional(),
   }),
 );
@@ -33,8 +36,14 @@ export const updateFormValidator = vine.compile(
   vine.object({
     name: vine.string().optional(),
     description: vine.string().optional(),
-    startDate: vine.date().transform(dateTimeTransform).optional(),
-    endDate: vine.date().transform(dateTimeTransform).optional(),
+    startDate: vine
+      .date({ formats: ["iso8601"] })
+      .transform(dateTimeTransform)
+      .optional(),
+    endDate: vine
+      .date({ formats: ["iso8601"] })
+      .transform(dateTimeTransform)
+      .optional(),
     attributes: vine
       .array(
         vine.object({


### PR DESCRIPTION
BREAKING CHANGE: use ISO-8601 date format for requests to server

