### PR TITLE
fix: make attribute slug unique to a specific event

### DIFF
--- a/app/controllers/attributes_controller.ts
+++ b/app/controllers/attributes_controller.ts
@@ -45,6 +45,7 @@ export default class AttributesController {
 
     const newAttributeData = await request.validateUsing(
       createAttributeValidator,
+      { meta: { eventId } },
     );
 
     const newAttribute = await this.attributeService.createAttribute({
@@ -92,7 +93,9 @@ export default class AttributesController {
 
     await bouncer.authorize("manage_setting", await Event.findOrFail(eventId));
 
-    const updates = await request.validateUsing(updateAttributeValidator);
+    const updates = await request.validateUsing(updateAttributeValidator, {
+      meta: { eventId },
+    });
 
     const updatedAttribute = this.attributeService.updateAttribute(
       eventId,

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -7,10 +7,11 @@ export const createAttributeSchema = vine.object({
   slug: vine
     .string()
     .unique(
-      async (db, value) =>
+      async (db, value, field) =>
         (await db
           .from("attributes")
           .where("slug", string.slug(value, { lower: true }))
+          .andWhere("event_id", +field.meta.eventId)
           .first()) === null,
     )
     .transform((value) => string.slug(value, { lower: true }))
@@ -47,10 +48,11 @@ export const UpdateAttributeSchema = vine.object({
   slug: vine
     .string()
     .unique(
-      async (db, value) =>
+      async (db, value, field) =>
         (await db
           .from("attributes")
           .where("slug", string.slug(value, { lower: true }))
+          .andWhere("event_id", +field.meta.eventId)
           .first()) === null,
     )
     .transform((value) => string.slug(value, { lower: true }))

--- a/database/migrations/1742475780310_alter_make_attribute_slug_unique_to_one_events_table.ts
+++ b/database/migrations/1742475780310_alter_make_attribute_slug_unique_to_one_events_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "attributes";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropUnique(["slug"]);
+      table.unique(["slug", "event_id"]);
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropUnique(["slug", "event_id"]);
+      table.unique(["slug"]);
+    });
+  }
+}


### PR DESCRIPTION
Closes #173
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `slug` uniqueness per event by updating validation logic and database schema in `attributes_controller.ts`, `attribute.ts`, and adding a new migration.
> 
>   - **Behavior**:
>     - In `attributes_controller.ts`, `store()` and `update()` methods now pass `eventId` as meta to validators to ensure `slug` uniqueness per event.
>   - **Validation**:
>     - In `attribute.ts`, `createAttributeSchema` and `UpdateAttributeSchema` updated to check `slug` uniqueness with `event_id`.
>   - **Database**:
>     - New migration `1742475780310_alter_make_attribute_slug_unique_to_one_events_table.ts` alters `attributes` table to make `slug` unique per `event_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 8e2d8797ca1e95467c9531fe94a101445319ef8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->