### PR TITLE
fix: don't count itself on attribute update slug uniqe

### DIFF
--- a/app/controllers/attributes_controller.ts
+++ b/app/controllers/attributes_controller.ts
@@ -94,7 +94,7 @@ export default class AttributesController {
     await bouncer.authorize("manage_setting", await Event.findOrFail(eventId));
 
     const updates = await request.validateUsing(updateAttributeValidator, {
-      meta: { eventId },
+      meta: { eventId, attributeId },
     });
 
     const updatedAttribute = this.attributeService.updateAttribute(

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -53,6 +53,7 @@ export const UpdateAttributeSchema = vine.object({
           .from("attributes")
           .where("slug", string.slug(value, { lower: true }))
           .andWhere("event_id", +field.meta.eventId)
+          .andWhereNot("id", +field.meta.attributeId)
           .first()) === null,
     )
     .transform((value) => string.slug(value, { lower: true }))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes slug uniqueness check during attribute update to exclude the current attribute itself.
> 
>   - **Behavior**:
>     - Fixes slug uniqueness check in `updateAttributeValidator` in `attribute.ts` to exclude the current attribute ID.
>     - Updates `update` method in `attributes_controller.ts` to pass `attributeId` for uniqueness validation.
>   - **Validation**:
>     - Adds `andWhereNot("id", +field.meta.attributeId)` in `UpdateAttributeSchema` to ensure the current attribute is not counted in uniqueness check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for c2dacacb54cd44f94ea433028f44aaf2182b966b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->