### PR TITLE
fix: add multiselect to validation on attribute create

### DIFF
--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -27,6 +27,7 @@ export const createAttributeSchema = vine.object({
     "date",
     "time",
     "datetime",
+    "multiselect",
     "email",
     "tel",
     "color",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'multiselect' to valid types in `createAttributeSchema` in `attribute.ts`.
> 
>   - **Validation**:
>     - Added `"multiselect"` to the `type` enum in `createAttributeSchema` in `attribute.ts` to allow 'multiselect' as a valid attribute type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 585e90612cee8e61450df954198f948e3dcf5133. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->