### PR TITLE
fix: remove organizer only from one event

### DIFF
--- a/app/controllers/organizers_controller.ts
+++ b/app/controllers/organizers_controller.ts
@@ -1,5 +1,6 @@
 import { inject } from "@adonisjs/core";
 import { HttpContext } from "@adonisjs/core/http";
+import db from "@adonisjs/lucid/services/db";
 
 import Admin from "#models/admin";
 import { OrganizerService } from "#services/organizer_service";
@@ -105,6 +106,10 @@ export default class OrganizersController {
     const eventId = +params.eventId;
     const organizerId = +params.id;
 
-    await this.organizerService.removeOrganizer(organizerId, eventId);
+    await db
+      .from("admin_permissions")
+      .where("admin_id", organizerId)
+      .where("event_id", eventId)
+      .delete();
   }
 }

--- a/app/services/organizer_service.ts
+++ b/app/services/organizer_service.ts
@@ -68,15 +68,4 @@ export class OrganizerService {
 
     return updatedOrganizer;
   }
-
-  async removeOrganizer(organizerId: number, eventId: number) {
-    const organizer = await this.getOrganizerWithPermissions(
-      organizerId,
-      eventId,
-    );
-
-    await organizer
-      .related("permissions")
-      .detach(organizer.permissions.map((permission) => permission.id));
-  }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `OrganizersController` to directly remove an organizer from an event using a database query, removing the `removeOrganizer` method from `OrganizerService`.
> 
>   - **Behavior**:
>     - In `organizers_controller.ts`, replace `removeOrganizer` method call with direct database query to remove organizer from a specific event.
>   - **Services**:
>     - Remove `removeOrganizer` method from `OrganizerService` in `organizer_service.ts`.
>   - **Imports**:
>     - Add `db` import in `organizers_controller.ts` for direct database access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for f40b17755d611d154498f5ec7e020c0d84bc68bd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->