### PR TITLE
fix: isMultipart is optional field

### DIFF
--- a/app/controllers/forms_controller.ts
+++ b/app/controllers/forms_controller.ts
@@ -239,7 +239,10 @@ export default class FormsController {
     // Transform attributes so that files work properly
     const transformedAttributes = Object.fromEntries(
       Object.entries(attributes).map(([key, value]) => {
-        if ((value as { isMultipartFile: boolean }).isMultipartFile) {
+        if (
+          (value as { isMultipartFile?: boolean })?.isMultipartFile ??
+          false
+        ) {
           return [key, request.file(key)];
         }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix optional handling of `isMultipartFile` in `FormsController.submitForm` to prevent runtime errors.
> 
>   - **Behavior**:
>     - In `FormsController.submitForm`, `isMultipartFile` is now treated as an optional field in the `attributes` object.
>     - Uses optional chaining and nullish coalescing to safely check `isMultipartFile` property.
>   - **Code**:
>     - Updated condition in `submitForm` method to handle cases where `isMultipartFile` is undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 266434e581ce0dd7e0ddbe9505ce8ee661cb8361. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->