### PR TITLE
fix: fix participant created date

### DIFF
--- a/app/controllers/participants_controller.ts
+++ b/app/controllers/participants_controller.ts
@@ -44,8 +44,9 @@ export default class ParticipantsController {
           slug: attribute.slug,
           value: attribute.$extras.pivot_value as string,
         })),
-        createdAt:
-          participant.createdAt?.toFormat("yyyy-MM-dd HH:mm:ss") ?? null,
+        createdAt: participant.createdAt
+          .setZone("Europe/Warsaw")
+          .toFormat("yyyy-MM-dd HH:mm:ss"),
       };
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `createdAt` date formatting to 'Europe/Warsaw' timezone in `participants_controller.ts`.
> 
>   - **Behavior**:
>     - In `participants_controller.ts`, `createdAt` for participants is now formatted in 'Europe/Warsaw' timezone using `setZone()` in the `index` method.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 41366a0e3678288aa04f94f63c289312ef3e927b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->