### PR TITLE
feat: use sendLater queue in emails

### DIFF
--- a/app/services/email_service.ts
+++ b/app/services/email_service.ts
@@ -46,8 +46,7 @@ export class EmailService {
     await participant.load("attributes", (q) => q.pivotColumns(["value"]));
     await event.load("mainOrganizer");
 
-    // use sendLater if you want to send emails in the background
-    await mail.send(async (message) => {
+    await mail.sendLater(async (message) => {
       message
         .to(participant.email)
         .from("eventownik@solvro.pl", event.name)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `mail.send` with `mail.sendLater` in `sendToParticipant` method in `email_service.ts` to queue emails for later sending.
> 
>   - **Behavior**:
>     - Replaces `mail.send` with `mail.sendLater` in `sendToParticipant` method in `email_service.ts` to queue emails for later sending.
>   - **Misc**:
>     - Removes comment about using `sendLater` for background email sending.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for e0d58d5b45b830af46700ce77ddc7823fc3fa66b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->