### PR TITLE
fix: attach images as cid

### DIFF
--- a/app/services/email_service.ts
+++ b/app/services/email_service.ts
@@ -1,5 +1,7 @@
 import { DateTime } from "luxon";
 
+import { cuid } from "@adonisjs/core/helpers";
+import { Message } from "@adonisjs/mail";
 import mail from "@adonisjs/mail/services/main";
 
 import Email from "#models/email";
@@ -52,7 +54,7 @@ export class EmailService {
         .from("eventownik@solvro.pl", event.name)
         .subject(email.name)
         .replyTo(event.contactEmail ?? event.mainOrganizer.email)
-        .html(this.parseContent(event, participant, email));
+        .html(this.parseContent(event, participant, email, message));
 
       await participant
         .related("emails")
@@ -63,7 +65,12 @@ export class EmailService {
     });
   }
 
-  static parseContent(event: Event, participant: Participant, email: Email) {
+  static parseContent(
+    event: Event,
+    participant: Participant,
+    email: Email,
+    message: Message,
+  ) {
     const content = email.content;
     let parsedContent = content
       .replace(/\/event_name/g, event.name)
@@ -86,7 +93,21 @@ export class EmailService {
       )
       .replace(/\/participant_email/g, participant.email)
       .replace(/\/participant_slug/g, participant.slug)
-      .replace(/"/g, '"');
+      .replace(
+        /data:image\/(\w+);base64,([^"]+)/g,
+        (_match, format, base64: string) => {
+          const cid = cuid();
+          message.nodeMailerMessage.attachments =
+            message.nodeMailerMessage.attachments ?? [];
+          message.nodeMailerMessage.attachments.push({
+            content: Buffer.from(base64, "base64"),
+            encoding: "base64",
+            filename: `${cid}.${format}`,
+            cid,
+          });
+          return `cid:${cid}`;
+        },
+      );
 
     for (const attribute of participant.attributes) {
       parsedContent = parsedContent.replace(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert base64 images in emails to attachments with CIDs in `EmailService`.
> 
>   - **Behavior**:
>     - Modify `parseContent` in `email_service.ts` to convert base64 images to attachments with CIDs in email messages.
>     - Images are detected using regex and attached to `message.nodeMailerMessage.attachments`.
>   - **Imports**:
>     - Add `cuid` and `Message` imports to support CID generation and message handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 7da391dc6ef8c47868bbf387074158bf82800f81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->