### PR TITLE
Refactor/blocks crud

### DIFF
--- a/app/controllers/attributes_controller.ts
+++ b/app/controllers/attributes_controller.ts
@@ -1,4 +1,5 @@
 import { inject } from "@adonisjs/core";
+import string from "@adonisjs/core/helpers/string";
 import type { HttpContext } from "@adonisjs/core/http";
 
 import Event from "#models/event";
@@ -52,6 +53,16 @@ export default class AttributesController {
       eventId,
       ...newAttributeData,
     });
+
+    if (newAttribute.type === "block") {
+      await newAttribute.related("blocks").create({
+        name: string.slug(
+          `${newAttribute.slug ?? newAttribute.name}-root-block`,
+          { lower: true },
+        ),
+        isRootBlock: true,
+      });
+    }
 
     return newAttribute;
   }

--- a/app/controllers/blocks_controller.ts
+++ b/app/controllers/blocks_controller.ts
@@ -46,10 +46,12 @@ export default class BlocksController {
    * @requestBody <createBlockValidator>
    * @responseBody 201 - <Block>
    */
+  async store({ request, params, response }: HttpContext) {
+    const attributeId = +params.attributeId;
 
-  async store({ request, response }: HttpContext) {
-    const data = await createBlockValidator.validate(request.all());
-    const block = await Block.create(data);
+    const data = await request.validateUsing(createBlockValidator);
+
+    const block = await Block.create({ ...data, attributeId });
 
     return response.created(block);
   }
@@ -63,7 +65,6 @@ export default class BlocksController {
    * @responseBody 200 - <Block>
    * @responseBody 404 - { "message": "Row not found", "name": "Exception", "status": 404 }
    */
-
   async update({ params, request }: HttpContext) {
     const data = await updateBlockValidator.validate(request.all());
     const block = await Block.findOrFail(params.id);
@@ -81,7 +82,6 @@ export default class BlocksController {
    * @responseBody 204 - No content
    * @responseBody 404 - { "message": "Row not found", "name": "Exception", "status": 404 }
    */
-
   async destroy({ params, response }: HttpContext) {
     const block = await Block.findOrFail(params.id);
     await block.delete();

--- a/app/controllers/blocks_controller.ts
+++ b/app/controllers/blocks_controller.ts
@@ -47,9 +47,19 @@ export default class BlocksController {
       .where("attribute_id", attributeId)
       .preload("parent")
       .preload("children")
+      .preload("attribute")
       .firstOrFail();
 
-    return block;
+    let participantsInBlock;
+
+    if (block.capacity !== null) {
+      participantsInBlock = await this.blockService.getBlockParticipants(
+        attributeId,
+        blockId,
+      );
+    }
+
+    return { ...block.serialize(), participantsInBlock };
   }
 
   /**

--- a/app/controllers/blocks_controller.ts
+++ b/app/controllers/blocks_controller.ts
@@ -1,9 +1,15 @@
+import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 
 import Block from "#models/block";
+import { BlockService } from "#services/block_service";
 import { createBlockValidator, updateBlockValidator } from "#validators/block";
 
+@inject()
 export default class BlocksController {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private blockService: BlockService) {}
+
   /**
    * @index
    * @operationId getBlocks
@@ -11,12 +17,10 @@ export default class BlocksController {
    * @tag blocks
    * @responseBody 200 - <Block[]>.paginated()
    */
+  async index({ params }: HttpContext) {
+    const attributeId = +params.attributeId;
 
-  async index({ request }: HttpContext) {
-    return await Block.query().paginate(
-      request.input("page", 1) | 1,
-      request.input("perPage", 10) | 10,
-    );
+    return await this.blockService.getBlockTree(attributeId);
   }
 
   /**

--- a/app/controllers/blocks_controller.ts
+++ b/app/controllers/blocks_controller.ts
@@ -2,6 +2,7 @@ import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 
 import Block from "#models/block";
+import Event from "#models/event";
 import { BlockService } from "#services/block_service";
 import { createBlockValidator, updateBlockValidator } from "#validators/block";
 
@@ -17,8 +18,11 @@ export default class BlocksController {
    * @tag blocks
    * @responseBody 200 - <Block[]>.paginated()
    */
-  async index({ params }: HttpContext) {
+  async index({ params, bouncer }: HttpContext) {
+    const eventId = +params.eventId;
     const attributeId = +params.attributeId;
+
+    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
 
     return await this.blockService.getBlockTree(attributeId);
   }
@@ -31,9 +35,12 @@ export default class BlocksController {
    * @responseBody 200 - <Block>
    * @responseBody 404 - { "message": "Row not found", "name": "Exception", "status": 404 }
    */
-  async show({ params }: HttpContext) {
+  async show({ params, bouncer }: HttpContext) {
+    const eventId = +params.eventId;
     const attributeId = +params.attributeId;
     const blockId = +params.id;
+
+    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
 
     const block = await Block.query()
       .where("id", blockId)
@@ -54,8 +61,11 @@ export default class BlocksController {
    * @requestBody <createBlockValidator>
    * @responseBody 201 - <Block>
    */
-  async store({ request, params, response }: HttpContext) {
+  async store({ request, params, response, bouncer }: HttpContext) {
+    const eventId = +params.eventId;
     const attributeId = +params.attributeId;
+
+    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
 
     const data = await request.validateUsing(createBlockValidator);
 
@@ -73,9 +83,12 @@ export default class BlocksController {
    * @responseBody 200 - <Block>
    * @responseBody 404 - { "message": "Row not found", "name": "Exception", "status": 404 }
    */
-  async update({ params, request }: HttpContext) {
+  async update({ params, request, bouncer }: HttpContext) {
+    const eventId = +params.eventId;
     const attributeId = +params.attributeId;
     const blockId = +params.id;
+
+    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
 
     const data = await request.validateUsing(updateBlockValidator);
 
@@ -99,9 +112,12 @@ export default class BlocksController {
    * @responseBody 204 - No content
    * @responseBody 404 - { "message": "Row not found", "name": "Exception", "status": 404 }
    */
-  async destroy({ params, response }: HttpContext) {
+  async destroy({ params, response, bouncer }: HttpContext) {
+    const eventId = +params.eventId;
     const attributeId = +params.attributeId;
     const blockId = +params.id;
+
+    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
 
     await Block.query()
       .where("id", blockId)

--- a/app/models/attribute.ts
+++ b/app/models/attribute.ts
@@ -1,19 +1,8 @@
 import { DateTime } from "luxon";
 
-import {
-  BaseModel,
-  belongsTo,
-  column,
-  hasOne,
-  manyToMany,
-} from "@adonisjs/lucid/orm";
-import type {
-  BelongsTo,
-  HasOne,
-  ManyToMany,
-} from "@adonisjs/lucid/types/relations";
+import { BaseModel, belongsTo, column, manyToMany } from "@adonisjs/lucid/orm";
+import type { BelongsTo, ManyToMany } from "@adonisjs/lucid/types/relations";
 
-import Block from "#models/block";
 import Event from "#models/event";
 import Form from "#models/form";
 
@@ -39,13 +28,7 @@ export default class Attribute extends BaseModel {
   declare type: string;
 
   @column()
-  declare rootBlockId: number | null;
-
-  @column()
   declare showInList: boolean;
-
-  @hasOne(() => Block)
-  declare rootBlock: HasOne<typeof Block>;
 
   @belongsTo(() => Event)
   declare event: BelongsTo<typeof Event>;

--- a/app/models/attribute.ts
+++ b/app/models/attribute.ts
@@ -1,8 +1,21 @@
 import { DateTime } from "luxon";
 
-import { BaseModel, belongsTo, column, manyToMany } from "@adonisjs/lucid/orm";
-import type { BelongsTo, ManyToMany } from "@adonisjs/lucid/types/relations";
+import {
+  BaseModel,
+  belongsTo,
+  column,
+  hasMany,
+  hasOne,
+  manyToMany,
+} from "@adonisjs/lucid/orm";
+import type {
+  BelongsTo,
+  HasMany,
+  HasOne,
+  ManyToMany,
+} from "@adonisjs/lucid/types/relations";
 
+import Block from "#models/block";
 import Event from "#models/event";
 import Form from "#models/form";
 
@@ -46,6 +59,14 @@ export default class Attribute extends BaseModel {
     pivotTimestamps: true,
   })
   declare participantAttributes: ManyToMany<typeof Participant>;
+
+  @hasOne(() => Block, {
+    onQuery: (query) => query.where("is_root_block", true),
+  })
+  declare rootBlock: HasOne<typeof Block>;
+
+  @hasMany(() => Block)
+  declare blocks: HasMany<typeof Block>;
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime;

--- a/app/models/block.ts
+++ b/app/models/block.ts
@@ -22,6 +22,9 @@ export default class Block extends BaseModel {
   declare capacity: number | null;
 
   @column()
+  declare isRootBlock: boolean;
+
+  @column()
   declare attributeId: number;
 
   @hasMany(() => Block, {

--- a/app/models/block.ts
+++ b/app/models/block.ts
@@ -21,6 +21,9 @@ export default class Block extends BaseModel {
   @column()
   declare capacity: number | null;
 
+  @column()
+  declare attributeId: number;
+
   @hasMany(() => Block, {
     foreignKey: "parentId",
   })

--- a/app/models/block.ts
+++ b/app/models/block.ts
@@ -45,4 +45,6 @@ export default class Block extends BaseModel {
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime;
+
+  serializeExtras = true;
 }

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -23,6 +23,17 @@ export class BlockService {
       await this.loadBlockTree(child);
     }
 
+    let participantsInBlockCount;
+
+    if (block.capacity !== null) {
+      participantsInBlockCount = await this.getBlockParticipantsCount(
+        block.attributeId,
+        block.id,
+      );
+
+      block.$extras.participantsInBlockCount = participantsInBlockCount;
+    }
+
     return block;
   }
 
@@ -36,5 +47,19 @@ export class BlockService {
     );
 
     return participantsInBlock;
+  }
+
+  async getBlockParticipantsCount(
+    attributeId: number,
+    blockId: number,
+  ): Promise<number> {
+    const blockParticipantsCount = await Participant.query()
+      .whereHas("attributes", (query) => {
+        void query.where("attributes.id", attributeId);
+        void query.where("participant_attributes.value", "like", blockId);
+      })
+      .count("*");
+
+    return +blockParticipantsCount[0].$extras.count;
   }
 }

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -19,9 +19,7 @@ export class BlockService {
   async loadBlockTree(block: Block) {
     await block.load("children");
 
-    for (const child of block.children) {
-      await this.loadBlockTree(child);
-    }
+    await Promise.all(block.children.map((child) => this.loadBlockTree(child)));
 
     let participantsInBlockCount;
 

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -62,4 +62,18 @@ export class BlockService {
 
     return +blockParticipantsCount[0].$extras.count;
   }
+
+  async canSignInToBlock(attributeId: number, blockId: number) {
+    const block = await Block.query()
+      .where("id", blockId)
+      .andWhere("attribute_id", attributeId)
+      .firstOrFail();
+
+    const blockParticipantsCount = await this.getBlockParticipantsCount(
+      attributeId,
+      blockId,
+    );
+
+    return block.capacity !== null && block.capacity > blockParticipantsCount;
+  }
 }

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -1,0 +1,27 @@
+import Attribute from "#models/attribute";
+import Block from "#models/block";
+
+export class BlockService {
+  async getBlockTree(attributeId: number) {
+    const blockAttribute = await Attribute.query()
+      .where("id", attributeId)
+      .preload("rootBlock")
+      .firstOrFail();
+
+    const rootBlock = blockAttribute.rootBlock;
+
+    const blockTree = await this.loadBlockTree(rootBlock);
+
+    return blockTree;
+  }
+
+  async loadBlockTree(block: Block) {
+    await block.load("children");
+
+    for (const child of block.children) {
+      await this.loadBlockTree(child);
+    }
+
+    return block;
+  }
+}

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -1,5 +1,6 @@
 import Attribute from "#models/attribute";
 import Block from "#models/block";
+import Participant from "#models/participant";
 
 export class BlockService {
   async getBlockTree(attributeId: number) {
@@ -23,5 +24,17 @@ export class BlockService {
     }
 
     return block;
+  }
+
+  async getBlockParticipants(attributeId: number, blockId: number) {
+    const participantsInBlock = await Participant.query().whereHas(
+      "attributes",
+      (query) => {
+        void query.where("attributes.id", attributeId);
+        void query.where("participant_attributes.value", "like", blockId);
+      },
+    );
+
+    return participantsInBlock;
   }
 }

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -8,6 +8,7 @@ import Participant from "#models/participant";
 
 import { FormSubmitDTO } from "../types/form_types.js";
 import { filterObjectFields } from "../utils/filter_object_fields.js";
+import { BlockService } from "./block_service.js";
 import { EmailService } from "./email_service.js";
 import { FileService } from "./file_service.js";
 import { ParticipantService } from "./participant_service.js";
@@ -18,6 +19,7 @@ export class FormService {
   constructor(
     private participantService: ParticipantService,
     private fileService: FileService,
+    private blockService: BlockService,
   ) {}
 
   async submitForm(
@@ -59,6 +61,12 @@ export class FormService {
         .map((attribute) => attribute.id),
     );
 
+    const blockAttributesIds = new Set(
+      form.attributes
+        .filter((attribute) => attribute.type === "block")
+        .map((attribute) => attribute.id),
+    );
+
     const allowedFieldsIds = form.attributes.map((attribute) =>
       attribute.id.toString(),
     );
@@ -95,6 +103,15 @@ export class FormService {
             attributeId: +attributeId,
             value: fileName,
           };
+        } else if (blockAttributesIds.has(+attributeId)) {
+          const canSignInToBlock = await this.blockService.canSignInToBlock(
+            +attributeId,
+            +(value as string),
+          );
+
+          if (!canSignInToBlock) {
+            throw new Exception("Block is full");
+          }
         }
 
         return {

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -34,11 +34,6 @@ export const createAttributeSchema = vine.object({
     "checkbox",
   ]),
   options: vine.array(vine.string()).minLength(2).optional(),
-  rootBlockId: vine
-    .number()
-    .nullable()
-    .optional()
-    .requiredWhen("type", "=", "block"),
   showInList: vine.boolean().optional(),
 });
 
@@ -79,11 +74,6 @@ export const UpdateAttributeSchema = vine.object({
     ])
     .optional(),
   options: vine.array(vine.string()).minLength(2).optional(),
-  rootBlockId: vine
-    .number()
-    .nullable()
-    .optional()
-    .requiredWhen("type", "=", "block"),
   showInList: vine.boolean().optional(),
 });
 

--- a/database/migrations/1744298920958_alter_blocks_table_add_attribute_id_columns_table.ts
+++ b/database/migrations/1744298920958_alter_blocks_table_add_attribute_id_columns_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "blocks";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.boolean("is_root_block").notNullable().defaultTo(false);
+    });
+
+    this.schema.raw(
+      `CREATE UNIQUE INDEX unique_root_block_per_attribute ON ${this.tableName} (attribute_id) WHERE is_root_block = true;`,
+    );
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn("is_root_block");
+
+      this.schema.raw("DROp INDEX IF EXISTS unique_root_block_per_attribute");
+    });
+  }
+}

--- a/database/migrations/1744298920958_alter_blocks_table_add_attribute_id_columns_table.ts
+++ b/database/migrations/1744298920958_alter_blocks_table_add_attribute_id_columns_table.ts
@@ -17,7 +17,7 @@ export default class extends BaseSchema {
     this.schema.alterTable(this.tableName, (table) => {
       table.dropColumn("is_root_block");
 
-      this.schema.raw("DROp INDEX IF EXISTS unique_root_block_per_attribute");
+      this.schema.raw("DROP INDEX IF EXISTS unique_root_block_per_attribute");
     });
   }
 }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -65,7 +65,11 @@ router
         router
           .group(() => {
             router.resource("attributes", AttributesController).apiOnly();
-            router.resource("blocks", BlocksController).apiOnly();
+            router
+              .group(() => {
+                router.resource("blocks", BlocksController).apiOnly();
+              })
+              .prefix("attributes/:attributeId");
             router.resource("emails", EmailsController).apiOnly();
             router.post("emails/send/:emailId", [EmailsController, "send"]);
             router.resource("forms", FormsController).apiOnly();


### PR DESCRIPTION
Zmiany:
- blocks index zwaraca całe drzewo bloków
- blocks show zwraca uczestników zapisanych do danego bloku
- jest validacja, czy blok jest pełny przed zapisaniem do niego uczestnika
- gdy tworzymy atrybut z typem "block" to automatycznie tworzy się root block dla tego atrybutu
- przeniosłem blocks controller z /events/:eventId do /events/:eventId/attributes/:attributeId

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactors block CRUD operations by introducing `BlockService`, updating controllers, models, and routes, and modifying the database schema.
> 
>   - **Controllers**:
>     - `AttributesController`: Adds root block creation for block-type attributes.
>     - `BlocksController`: Refactors CRUD operations to use `BlockService` and adds authorization checks.
>   - **Services**:
>     - New `BlockService` handles block tree retrieval, participant count, and block capacity checks.
>   - **Models**:
>     - `Attribute`: Removes `rootBlockId`, adds `blocks` relation.
>     - `Block`: Adds `isRootBlock` and `attributeId` columns.
>   - **Validators**:
>     - `attribute.ts`: Removes `rootBlockId` validation.
>   - **Database**:
>     - Migration adds `is_root_block` column to `blocks` table and unique index for root blocks.
>   - **Routes**:
>     - Updates routes to nest `blocks` under `attributes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for ebdf385d46c4c85cf0c2cd82e0b50b18fb82fc1c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->