### PR TITLE
Feat/create root block after attribute update

### DIFF
--- a/app/controllers/attributes_controller.ts
+++ b/app/controllers/attributes_controller.ts
@@ -1,5 +1,4 @@
 import { inject } from "@adonisjs/core";
-import string from "@adonisjs/core/helpers/string";
 import type { HttpContext } from "@adonisjs/core/http";
 
 import Event from "#models/event";
@@ -53,16 +52,6 @@ export default class AttributesController {
       eventId,
       ...newAttributeData,
     });
-
-    if (newAttribute.type === "block") {
-      await newAttribute.related("blocks").create({
-        name: string.slug(
-          `${newAttribute.slug ?? newAttribute.name}-root-block`,
-          { lower: true },
-        ),
-        isRootBlock: true,
-      });
-    }
 
     return newAttribute;
   }

--- a/app/services/attribute_service.ts
+++ b/app/services/attribute_service.ts
@@ -1,11 +1,18 @@
+import { inject } from "@adonisjs/core";
+
 import Attribute from "#models/attribute";
 
 import {
   CreateAttributeDTO,
   UpdateAttributeDTO,
 } from "../types/attribute_types.js";
+import { BlockService } from "./block_service.js";
 
+@inject()
 export class AttributeService {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private blockService: BlockService) {}
+
   async getEventAttributes(eventId: number) {
     const attributes = await Attribute.findManyBy("event_id", eventId);
 
@@ -31,6 +38,10 @@ export class AttributeService {
       ...createAttributeDTO,
       options: optionsJSON,
     });
+
+    if (newAttribute.type === "block") {
+      await this.blockService.createRootBlock(newAttribute.id);
+    }
 
     return newAttribute;
   }

--- a/app/services/attribute_service.ts
+++ b/app/services/attribute_service.ts
@@ -56,6 +56,8 @@ export class AttributeService {
       attributeId,
     );
 
+    const previousType = attributeToUpdate.type;
+
     const optionsJSON: string | undefined =
       updates.options !== undefined
         ? JSON.stringify(updates.options)
@@ -70,7 +72,18 @@ export class AttributeService {
 
     const updatedAttribute = await this.getEventAttribute(eventId, attributeId);
 
-    return updatedAttribute;
+    if (updatedAttribute.type === "block") {
+      await this.blockService.createRootBlock(updatedAttribute.id);
+    } else if (previousType === "block") {
+      await updatedAttribute.load("rootBlock");
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (updatedAttribute.rootBlock !== null) {
+        await updatedAttribute.rootBlock.delete();
+      }
+    }
+
+    return await this.getEventAttribute(eventId, attributeId);
   }
 
   async deleteAttribute(eventId: number, attributeId: number) {

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -1,3 +1,5 @@
+import string from "@adonisjs/core/helpers/string";
+
 import Attribute from "#models/attribute";
 import Block from "#models/block";
 import Participant from "#models/participant";
@@ -73,5 +75,16 @@ export class BlockService {
     );
 
     return block.capacity !== null && block.capacity > blockParticipantsCount;
+  }
+
+  async createRootBlock(attributeId: number) {
+    const attribute = await Attribute.findOrFail(attributeId);
+
+    await attribute.related("blocks").create({
+      name: string.slug(`${attribute.slug ?? attribute.name}-root-block`, {
+        lower: true,
+      }),
+      isRootBlock: true,
+    });
   }
 }

--- a/app/services/block_service.ts
+++ b/app/services/block_service.ts
@@ -78,7 +78,15 @@ export class BlockService {
   }
 
   async createRootBlock(attributeId: number) {
-    const attribute = await Attribute.findOrFail(attributeId);
+    const attribute = await Attribute.query()
+      .where("id", attributeId)
+      .preload("rootBlock")
+      .firstOrFail();
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (attribute.rootBlock !== null) {
+      await attribute.rootBlock.delete();
+    }
 
     await attribute.related("blocks").create({
       name: string.slug(`${attribute.slug ?? attribute.name}-root-block`, {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor root block creation logic for 'block' type attributes into `BlockService` and update `AttributeService` to use it.
> 
>   - **Behavior**:
>     - Moves root block creation logic from `AttributesController` to `AttributeService`.
>     - Adds `createRootBlock()` in `BlockService` to handle root block creation.
>     - On attribute update, creates a root block if type changes to 'block', deletes if type changes from 'block'.
>   - **Services**:
>     - `AttributeService` now uses `BlockService` for root block operations.
>     - `BlockService` provides `createRootBlock()` to manage root block lifecycle.
>   - **Misc**:
>     - Removes unused import `string` from `attributes_controller.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 9821aa8ed85a7e0254ff22ddb3fed8761fb12ab7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->