### PR TITLE
Feat/get blocks without authorization

### DIFF
--- a/app/controllers/blocks_controller.ts
+++ b/app/controllers/blocks_controller.ts
@@ -1,6 +1,7 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 
+import Attribute from "#models/attribute";
 import Block from "#models/block";
 import Event from "#models/event";
 import { BlockService } from "#services/block_service";
@@ -18,13 +19,12 @@ export default class BlocksController {
    * @tag blocks
    * @responseBody 200 - <Block[]>.paginated()
    */
-  async index({ params, bouncer }: HttpContext) {
-    const eventId = +params.eventId;
-    const attributeId = +params.attributeId;
+  async index({ params }: HttpContext) {
+    const attributeSlug = params.attributeSlug as string;
 
-    await bouncer.authorize("manage_event", await Event.findOrFail(eventId));
+    const attribute = await Attribute.findByOrFail("slug", attributeSlug);
 
-    return await this.blockService.getBlockTree(attributeId);
+    return await this.blockService.getBlockTree(attribute.id);
   }
 
   /**

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -42,6 +42,10 @@ router
         router
           .get("forms/:formSlug", [FormsController, "showBySlug"])
           .where("formSlug", router.matchers.slug());
+        router.get("attributes/:attributeId/blocks", [
+          BlocksController,
+          "index",
+        ]);
         router
           .group(() => {
             router
@@ -67,7 +71,10 @@ router
             router.resource("attributes", AttributesController).apiOnly();
             router
               .group(() => {
-                router.resource("blocks", BlocksController).apiOnly();
+                router
+                  .resource("blocks", BlocksController)
+                  .apiOnly()
+                  .except(["index"]);
                 router.put("bulk-update", [
                   ParticipantsAttributesController,
                   "bulkUpdate",

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -42,10 +42,9 @@ router
         router
           .get("forms/:formSlug", [FormsController, "showBySlug"])
           .where("formSlug", router.matchers.slug());
-        router.get("attributes/:attributeId/blocks", [
-          BlocksController,
-          "index",
-        ]);
+        router
+          .get("attributes/:attributeSlug/blocks", [BlocksController, "index"])
+          .where("attributeSlug", router.matchers.slug());
         router
           .group(() => {
             router


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `index()` in `BlocksController` now allows public access to blocks by `attributeSlug`, with corresponding route changes.
> 
>   - **Behavior**:
>     - `index()` in `BlocksController` no longer requires authorization, allowing public access to blocks by `attributeSlug`.
>     - Route `GET /attributes/:attributeSlug/blocks` added for public access to blocks.
>     - `blocks` resource routes in `routes.ts` exclude `index` to maintain authorization for other actions.
>   - **Misc**:
>     - Removed `bouncer.authorize` call from `index()` in `blocks_controller.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for e110c99ec75a9ca60ec85e3375519757a4ab6e09. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->