### PR TITLE
fix: make options nullable in attribute validator

### DIFF
--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -33,7 +33,7 @@ export const createAttributeSchema = vine.object({
     "color",
     "checkbox",
   ]),
-  options: vine.array(vine.string()).minLength(1).optional(),
+  options: vine.array(vine.string()).minLength(1).nullable().optional(),
   showInList: vine.boolean().optional(),
 });
 
@@ -73,7 +73,7 @@ export const UpdateAttributeSchema = vine.object({
       "checkbox",
     ])
     .optional(),
-  options: vine.array(vine.string()).minLength(1).optional(),
+  options: vine.array(vine.string()).minLength(1).nullable().optional(),
   showInList: vine.boolean().optional(),
 });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `options` field nullable in `createAttributeSchema` and `UpdateAttributeSchema` in `attribute.ts`.
> 
>   - **Behavior**:
>     - Make `options` field nullable in `createAttributeSchema` and `UpdateAttributeSchema` in `attribute.ts`.
>     - Allows `options` to be explicitly set to `null` in both schemas.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 66b96235ce540c9a917993177a1bb2016e90b097. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->