### PR TITLE
fix: remove event permissions from event show endpoint

### DIFF
--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -81,12 +81,9 @@ export default class EventController {
    * @responseBody 401 - Unauthorized access
    * @tag event
    */
-  public async show({ params, auth, bouncer }: HttpContext) {
+  public async show({ params, bouncer }: HttpContext) {
     const event = await Event.query()
       .where("id", Number(params.id))
-      .preload("permissions", (q) =>
-        q.where("admin_permissions.admin_id", auth.user?.id ?? 0),
-      )
       .preload("firstForm")
       .first();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes permissions preload from `show()` in `EventController`, simplifying the query and maintaining authorization with `bouncer`.
> 
>   - **Behavior**:
>     - Removes permissions preload in `show()` method of `EventController`.
>     - Simplifies event query by removing dependency on `auth` object.
>   - **Authorization**:
>     - Maintains authorization check with `bouncer.authorize()` for event management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 998850b5ea068b0c850ab337e2a728b76514faf8. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->