### PR TITLE
Fix/event show endpopint

### DIFF
--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -81,9 +81,12 @@ export default class EventController {
    * @responseBody 401 - Unauthorized access
    * @tag event
    */
-  public async show({ params, bouncer }: HttpContext) {
+  public async show({ params, auth, bouncer }: HttpContext) {
     const event = await Event.query()
       .where("id", Number(params.id))
+      .preload("permissions", (q) =>
+        q.where("admin_permissions.admin_id", auth.user?.id ?? 0),
+      )
       .preload("firstForm")
       .first();
 

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -42,7 +42,7 @@ router
           BlocksController,
           "publicIndex",
         ]);
-        router.get("", [EventController, "publicShow"]);
+        router.get("public", [EventController, "publicShow"]);
         router
           .get("forms/:formSlug", [FormsController, "showBySlug"])
           .where("formSlug", router.matchers.slug());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `show()` in `EventController` to preload user-specific permissions and update public event route for clarity.
> 
>   - **Behavior**:
>     - `show()` in `events_controller.ts` now preloads `permissions` for the authenticated user.
>     - Route for `publicShow` in `routes.ts` changed from `""` to `"public"`.
>   - **Security**:
>     - Ensures only authorized users can view event permissions in `show()` method.
>   - **Routing**:
>     - Adjusts public event access route to `"public"` for clarity and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik&utm_source=github&utm_medium=referral)<sup> for 82f7e4245066ea5d2af09affef11903c3acd9179. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->