### PR TITLE
fix: add missing order field to attribute validator

### DIFF
--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -34,6 +34,7 @@ export const createAttributeSchema = vine.object({
     "checkbox",
   ]),
   options: vine.array(vine.string()).minLength(1).nullable().optional(),
+  order: vine.number().optional(),
   showInList: vine.boolean().optional(),
   isSensitiveData: vine.boolean().optional(),
   reason: vine.string().optional().requiredWhen("isSensitiveData", "=", true),
@@ -76,6 +77,7 @@ export const UpdateAttributeSchema = vine.object({
     ])
     .optional(),
   options: vine.array(vine.string()).minLength(1).nullable().optional(),
+  order: vine.number().optional(),
   showInList: vine.boolean().optional(),
   isSensitiveData: vine.boolean().optional(),
   reason: vine.string().optional().requiredWhen("isSensitiveData", "=", true),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `order` field to attribute validators in `attribute.ts`.
> 
>   - **Validators**:
>     - Add optional `order` field to `createAttributeSchema` and `UpdateAttributeSchema` in `attribute.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik-v2-legacy&utm_source=github&utm_medium=referral)<sup> for cd89c23bdef7a1431c9e6140b992a44ba3fa5305. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->