### PR TITLE
feat(events/public): return only the events activated by the superadmin

### DIFF
--- a/app/controllers/events_controller.ts
+++ b/app/controllers/events_controller.ts
@@ -126,6 +126,7 @@ export default class EventController {
   public async publicIndex({ request }: HttpContext) {
     const params = await request.validateUsing(displayEvents);
     const events = await Event.query()
+      .where("isActive", true)
       .if(params.from, (q) =>
         q.where("start_date", ">=", params.from.toFormat("yyyy-MM-dd")),
       )


### PR DESCRIPTION
Hej, na froncie chcemy użyć endpoint'u `/events/public` do wyświetlania wydarzeń na stronie głównej, ale na razie ten endpoint zwraca wszystkie wydarzenia - dodałem tutaj proste `where` które sprawdza czy wydarzenie ma `isActive: true` żeby zwracało tylko te zaakceptowane przez superadmina. Jak sprawdzałem u siebie lokalnie to działa, mam nadzieję że u was też będzie
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Filter `publicIndex` in `events_controller.ts` to return only active events approved by superadmin.
> 
>   - **Behavior**:
>     - Modify `publicIndex` in `events_controller.ts` to filter events by `isActive: true`, ensuring only superadmin-approved events are returned.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for a2c5baafd9ff1e11e2ff3f144a04848cd2f71510. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->