### PR TITLE
feat(admin): allow admin to remove self

### DIFF
--- a/app/controllers/admins_controller.ts
+++ b/app/controllers/admins_controller.ts
@@ -104,12 +104,14 @@ export default class AdminsController {
   /**
    * @destroy
    * @operationId deleteAdmin
-   * @description Deletes an admin
+   * @description Deletes an admin. Superadmins can delete any admin. Regular admins can only delete themselves.
    * @tag admins
    * @responseBody 204 - {}
    */
   async destroy({ params, response, auth }: HttpContext) {
-    if (auth.getUserOrFail().type !== "superadmin") {
+    const admin = auth.getUserOrFail();
+
+    if (admin.type !== "superadmin" && admin.id !== +params.id) {
       return response.unauthorized();
     }
 


### PR DESCRIPTION
Hej, piszę testy E2E do wydarzeń na froncie, gdzie tworzę użytkownika do testów, a po testach go usuwam. Obecnie nie ma możliwości żeby użytkownik mógł usunąć własne konto (może to zrobić tylko superadmin) - chcę to zmienić tą PRką.
Dajcie znać co myślicie :)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Regular admins can now delete their own accounts in `destroy()` in `admins_controller.ts`, while superadmins can delete any admin.
> 
>   - **Behavior**:
>     - Regular admins can now delete their own accounts in `destroy()` in `admins_controller.ts`.
>     - Superadmins retain the ability to delete any admin account.
>   - **Documentation**:
>     - Update `@description` in `destroy()` to reflect new deletion permissions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 73ed8bdda84a1dc0b6e686bef41a86572cb7ba1d. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->