### PR TITLE
feat/drawing attribute type

### DIFF
--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -80,7 +80,10 @@ export class FormService {
 
     const fileAttributesIds = new Set(
       form.attributes
-        .filter((attribute) => attribute.type === "file")
+        .filter(
+          (attribute) =>
+            attribute.type === "file" || attribute.type === "drawing",
+        )
         .map((attribute) => attribute.id),
     );
 

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -32,6 +32,7 @@ export const createAttributeSchema = vine.object({
     "tel",
     "color",
     "checkbox",
+    "drawing",
   ]),
   options: vine.array(vine.string()).minLength(1).nullable().optional(),
   order: vine.number().optional(),
@@ -74,6 +75,7 @@ export const UpdateAttributeSchema = vine.object({
       "tel",
       "color",
       "checkbox",
+      "drawing",
     ])
     .optional(),
   options: vine.array(vine.string()).minLength(1).nullable().optional(),

--- a/database/migrations/1768299221955_alter_attributes_add_drawing_types_table.ts
+++ b/database/migrations/1768299221955_alter_attributes_add_drawing_types_table.ts
@@ -1,0 +1,25 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "attributes_add_drawing_types";
+
+  async up() {
+    this.schema.raw(`
+      ALTER TYPE attribute_type ADD VALUE 'drawing';
+    `);
+  }
+
+  public async down() {
+    this.schema.raw(`
+      CREATE TYPE attribute_type_old AS ENUM ('text', 'number', 'file', 'select', 'block', 'date', 'time', 'datetime', 'email', 'tel', 'color', 'checkbox', 'textarea', 'multiselect');
+
+      UPDATE attributes SET type = 'file' WHERE type = 'drawing';
+
+      ALTER TABLE attributes ALTER COLUMN type TYPE attribute_type_old USING type::text::attribute_type_old;
+
+      DROP TYPE attribute_type;
+
+      ALTER TYPE attribute_type_old RENAME TO attribute_type;
+    `);
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `drawing` attribute type in form handling, validation, and database schema.
> 
>   - **Behavior**:
>     - Add support for `drawing` attribute type in `FormService` by including it in `fileAttributesIds` set.
>     - Update form submission logic to handle `drawing` type similarly to `file` type.
>   - **Validation**:
>     - Add `drawing` to `type` enum in `createAttributeSchema` and `UpdateAttributeSchema` in `attribute.ts`.
>   - **Database**:
>     - New migration `1768299221955_alter_attributes_add_drawing_types_table.ts` to add `drawing` to `attribute_type` enum.
>     - Migration `down` method reverts `drawing` type to `file` and restores original enum.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for b55c2d50e31fac2f4f7ead2a2223a9a21647e88a. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->