### PR TITLE
Feat/other value in select attribute

### DIFF
--- a/app/models/attribute.ts
+++ b/app/models/attribute.ts
@@ -52,6 +52,9 @@ export default class Attribute extends BaseModel {
   @column()
   declare reason: string;
 
+  @column()
+  declare allowOther: boolean;
+
   @belongsTo(() => Event)
   declare event: BelongsTo<typeof Event>;
 

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -236,8 +236,9 @@ export class FormService {
           let parsedOptions: string[] = [];
           if (typeof attribute.options === "string") {
             try {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               parsedOptions = JSON.parse(attribute.options);
-            } catch (e) {
+            } catch {
               parsedOptions = [];
             }
           } else if (Array.isArray(attribute.options)) {
@@ -250,18 +251,19 @@ export class FormService {
             if (Array.isArray(value)) {
               selectedValues = value.map((v) => String(v));
             } else {
+              const valStr = String(value as string | number | boolean);
               try {
-                const parsed = JSON.parse(String(value));
+                const parsed: unknown = JSON.parse(valStr);
                 if (Array.isArray(parsed)) {
-                  selectedValues = parsed.map((v) => String(v));
+                  selectedValues = (parsed as unknown[]).map((v) => String(v));
                 } else {
-                  selectedValues = [String(value)];
+                  selectedValues = [String(valStr)];
                 }
               } catch {
-                if (String(value).includes(",")) {
-                  selectedValues = String(value).split(",");
+                if (valStr.includes(",")) {
+                  selectedValues = valStr.split(",");
                 } else {
-                  selectedValues = [String(value)];
+                  selectedValues = [valStr];
                 }
               }
             }
@@ -271,7 +273,7 @@ export class FormService {
                 (v) => !parsedOptions.includes(v),
               );
 
-              if (invalidOption) {
+              if (invalidOption !== undefined) {
                 return {
                   status: 400,
                   error: {
@@ -287,14 +289,12 @@ export class FormService {
             });
             continue;
           } else {
-            if (
-              !attribute.allowOther &&
-              !parsedOptions.includes(String(value))
-            ) {
+            const valStr = String(value as string | number | boolean);
+            if (!attribute.allowOther && !parsedOptions.includes(valStr)) {
               return {
                 status: 400,
                 error: {
-                  message: `Invalid option selected for attribute ${attribute.name} - Option ${value} not found in ${JSON.stringify(parsedOptions)}`,
+                  message: `Invalid option selected for attribute ${attribute.name} - Option ${valStr} not found in ${JSON.stringify(parsedOptions)}`,
                 },
               };
             }

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -165,10 +165,10 @@ export class FormService {
       allowedFieldsIds,
     );
 
-    const transformedFormFields: Array<{
+    const transformedFormFields: {
       attributeId: number;
       value: string | null;
-    }> = [];
+    }[] = [];
 
     for (const [attributeIdStr, value] of Object.entries(formFields)) {
       const attributeId = +attributeIdStr;
@@ -229,14 +229,15 @@ export class FormService {
 
       // select/multiselect handling
       if (
-        attribute &&
+        attribute !== undefined &&
         (attribute.type === "select" || attribute.type === "multiselect")
       ) {
         if (value !== null && value !== "null") {
-          const parsedOptions =
+          const parsedOptions = (
             typeof attribute.options === "string"
               ? JSON.parse(attribute.options)
-              : attribute.options || [];
+              : []
+          ) as string[];
 
           if (
             !attribute.allowOther &&

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -168,6 +168,8 @@ export class FormService {
 
     const transformedFormFields = await Promise.all(
       Object.entries(formFields).map(async ([attributeId, value]) => {
+        const attribute = form.attributes.find((a) => a.id === +attributeId);
+
         if (
           fileAttributesIds.has(+attributeId) &&
           value !== null &&
@@ -203,6 +205,27 @@ export class FormService {
 
           if (!canSignInToBlock) {
             throw new Exception("Block is full");
+          }
+        }
+
+        if (
+          attribute &&
+          (attribute.type === "select" || attribute.type === "multiselect")
+        ) {
+          if (value !== null && value !== "null") {
+            const parsedOptions =
+              typeof attribute.options === "string"
+                ? JSON.parse(attribute.options)
+                : attribute.options || [];
+
+            if (
+              !attribute.allowOther &&
+              !parsedOptions.includes(value as string)
+            ) {
+              throw new Exception(
+                `Invalid option selected for attribute ${attribute.name}`,
+              );
+            }
           }
         }
 

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -233,22 +233,71 @@ export class FormService {
         (attribute.type === "select" || attribute.type === "multiselect")
       ) {
         if (value !== null && value !== "null") {
-          const parsedOptions = (
-            typeof attribute.options === "string"
-              ? JSON.parse(attribute.options)
-              : []
-          ) as string[];
+          let parsedOptions: string[] = [];
+          if (typeof attribute.options === "string") {
+            try {
+              parsedOptions = JSON.parse(attribute.options);
+            } catch (e) {
+              parsedOptions = [];
+            }
+          } else if (Array.isArray(attribute.options)) {
+            parsedOptions = attribute.options;
+          }
+          parsedOptions = parsedOptions.map((v) => String(v));
 
-          if (
-            !attribute.allowOther &&
-            !parsedOptions.includes(value as string)
-          ) {
-            return {
-              status: 400,
-              error: {
-                message: `Invalid option selected for attribute ${attribute.name}`,
-              },
-            };
+          if (attribute.type === "multiselect") {
+            let selectedValues: string[] = [];
+            if (Array.isArray(value)) {
+              selectedValues = value.map((v) => String(v));
+            } else {
+              try {
+                const parsed = JSON.parse(String(value));
+                if (Array.isArray(parsed)) {
+                  selectedValues = parsed.map((v) => String(v));
+                } else {
+                  selectedValues = [String(value)];
+                }
+              } catch {
+                if (String(value).includes(",")) {
+                  selectedValues = String(value).split(",");
+                } else {
+                  selectedValues = [String(value)];
+                }
+              }
+            }
+
+            if (!attribute.allowOther) {
+              const invalidOption = selectedValues.find(
+                (v) => !parsedOptions.includes(v),
+              );
+
+              if (invalidOption) {
+                return {
+                  status: 400,
+                  error: {
+                    message: `Invalid option selected for attribute ${attribute.name} - Option ${invalidOption} not found in ${JSON.stringify(parsedOptions)}`,
+                  },
+                };
+              }
+            }
+
+            transformedFormFields.push({
+              attributeId,
+              value: selectedValues.join(","),
+            });
+            continue;
+          } else {
+            if (
+              !attribute.allowOther &&
+              !parsedOptions.includes(String(value))
+            ) {
+              return {
+                status: 400,
+                error: {
+                  message: `Invalid option selected for attribute ${attribute.name} - Option ${value} not found in ${JSON.stringify(parsedOptions)}`,
+                },
+              };
+            }
           }
         }
       }

--- a/app/services/form_service.ts
+++ b/app/services/form_service.ts
@@ -1,6 +1,5 @@
 import { inject } from "@adonisjs/core";
 import { MultipartFile } from "@adonisjs/core/bodyparser";
-import { Exception } from "@adonisjs/core/exceptions";
 
 import Event from "#models/event";
 import Form from "#models/form";
@@ -166,75 +165,98 @@ export class FormService {
       allowedFieldsIds,
     );
 
-    const transformedFormFields = await Promise.all(
-      Object.entries(formFields).map(async ([attributeId, value]) => {
-        const attribute = form.attributes.find((a) => a.id === +attributeId);
+    const transformedFormFields: Array<{
+      attributeId: number;
+      value: string | null;
+    }> = [];
 
-        if (
-          fileAttributesIds.has(+attributeId) &&
-          value !== null &&
-          value !== "null"
-        ) {
-          const fileName = await this.fileService.storeFile(
-            value as MultipartFile,
-          );
+    for (const [attributeIdStr, value] of Object.entries(formFields)) {
+      const attributeId = +attributeIdStr;
+      const attribute = form.attributes.find((a) => a.id === attributeId);
 
-          if (fileName === undefined) {
-            throw new Exception("Error while saving a file");
-          }
+      // file handling
+      if (
+        fileAttributesIds.has(attributeId) &&
+        value !== null &&
+        value !== "null"
+      ) {
+        const fileName = await this.fileService.storeFile(
+          value as MultipartFile,
+        );
 
+        if (fileName === undefined) {
           return {
-            attributeId: +attributeId,
-            value: fileName,
+            status: 500,
+            error: { message: "Error while saving a file" },
           };
-        } else if (
-          blockAttributesIds.has(+attributeId) &&
-          value !== null &&
-          value !== "null"
-        ) {
-          const blockId = Number(value);
-
-          if (Number.isNaN(blockId)) {
-            throw new Exception("Invalid block ID format");
-          }
-
-          const canSignInToBlock = await this.blockService.canSignInToBlock(
-            +attributeId,
-            blockId,
-          );
-
-          if (!canSignInToBlock) {
-            throw new Exception("Block is full");
-          }
         }
 
-        if (
-          attribute &&
-          (attribute.type === "select" || attribute.type === "multiselect")
-        ) {
-          if (value !== null && value !== "null") {
-            const parsedOptions =
-              typeof attribute.options === "string"
-                ? JSON.parse(attribute.options)
-                : attribute.options || [];
+        transformedFormFields.push({ attributeId, value: fileName });
+        continue;
+      }
 
-            if (
-              !attribute.allowOther &&
-              !parsedOptions.includes(value as string)
-            ) {
-              throw new Exception(
-                `Invalid option selected for attribute ${attribute.name}`,
-              );
-            }
-          }
+      // block handling
+      if (
+        blockAttributesIds.has(attributeId) &&
+        value !== null &&
+        value !== "null"
+      ) {
+        const blockId = Number(value);
+
+        if (Number.isNaN(blockId)) {
+          return {
+            status: 400,
+            error: {
+              message: `Invalid block ID format for attribute ${attribute?.name}`,
+            },
+          };
         }
 
-        return {
-          attributeId: +attributeId,
-          value: value as string | null,
-        };
-      }),
-    );
+        const canSignInToBlock = await this.blockService.canSignInToBlock(
+          attributeId,
+          blockId,
+        );
+
+        if (!canSignInToBlock) {
+          return {
+            status: 400,
+            error: {
+              message: `Block is full for attribute ${attribute?.name}`,
+            },
+          };
+        }
+      }
+
+      // select/multiselect handling
+      if (
+        attribute &&
+        (attribute.type === "select" || attribute.type === "multiselect")
+      ) {
+        if (value !== null && value !== "null") {
+          const parsedOptions =
+            typeof attribute.options === "string"
+              ? JSON.parse(attribute.options)
+              : attribute.options || [];
+
+          if (
+            !attribute.allowOther &&
+            !parsedOptions.includes(value as string)
+          ) {
+            return {
+              status: 400,
+              error: {
+                message: `Invalid option selected for attribute ${attribute.name}`,
+              },
+            };
+          }
+        }
+      }
+
+      transformedFormFields.push({
+        attributeId,
+        value: value as string | null,
+      });
+    }
 
     if (participantEmail !== undefined) {
       participant = await this.participantService.createParticipant(event.id, {

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -103,6 +103,7 @@ export const bulkAttributeSchema = vine.array(
     showInList: vine.boolean().optional(),
     isSensitiveData: vine.boolean().optional(),
     reason: vine.string().optional().requiredWhen("isSensitiveData", "=", true),
+    allowOther: vine.boolean().optional(),
   }),
 );
 

--- a/app/validators/attribute.ts
+++ b/app/validators/attribute.ts
@@ -39,6 +39,7 @@ export const createAttributeSchema = vine.object({
   showInList: vine.boolean().optional(),
   isSensitiveData: vine.boolean().optional(),
   reason: vine.string().optional().requiredWhen("isSensitiveData", "=", true),
+  allowOther: vine.boolean().optional(),
 });
 
 export const createAttributeValidator = vine.compile(createAttributeSchema);
@@ -83,6 +84,7 @@ export const UpdateAttributeSchema = vine.object({
   showInList: vine.boolean().optional(),
   isSensitiveData: vine.boolean().optional(),
   reason: vine.string().optional().requiredWhen("isSensitiveData", "=", true),
+  allowOther: vine.boolean().optional(),
 });
 
 export const updateAttributeValidator = vine.compile(UpdateAttributeSchema);

--- a/database/migrations/1772032725429_alter_add_allow_other_to_attributes_table.ts
+++ b/database/migrations/1772032725429_alter_add_allow_other_to_attributes_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "attributes";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.boolean("allow_other").defaultTo(false).notNullable();
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn("allow_other");
+    });
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for 'other' values in select attributes by introducing `allowOther` in the model, service, validator, and database schema.
> 
>   - **Behavior**:
>     - Add `allowOther` boolean column to `Attribute` model in `attribute.ts` to support 'other' values in select/multiselect attributes.
>     - Update `submitForm()` in `form_service.ts` to handle 'other' values for select/multiselect attributes, returning an error if an invalid option is selected and `allowOther` is false.
>   - **Validation**:
>     - Add `allowOther` to `createAttributeSchema` and `UpdateAttributeSchema` in `attribute.ts`.
>   - **Database**:
>     - Add migration `1772032725429_alter_add_allow_other_to_attributes_table.ts` to add `allow_other` column to `attributes` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for c980d57fc5bed6d1f5f394639daa31aa60baa329. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->